### PR TITLE
only allow /write from outside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Ingress auth using Grafana authentication.
 - Add ServiceMonitor for Prometheus scrape to take place.
 
+### Changed
+
+- Restrict ingress to /write
+
 ## [0.1.1] - 2021-07-29
 
 ### Changed

--- a/helm/macropower-analytics-panel-server/templates/ingress.yaml
+++ b/helm/macropower-analytics-panel-server/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/auth-url: https://$host/grafana-auth
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/rewrite-target: /write
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
@@ -17,5 +17,5 @@ spec:
       - backend:
           serviceName: {{ include "resource.default.name" . }}
           servicePort: {{ .Values.server.service.port }}
-        path: /{{ .Values.server.ingress.path }}(/|$)(.*)
+        path: /{{ .Values.server.ingress.path }}/write
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/398


Only allow /write from ingress, so we keep /metrics only accessible internally.