### PR TITLE
Support overriding server args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Ingress auth using Grafana authentication.
-
-### Changed
-
-- Avoids storing user labels (`user_name`, `user_email`) in metrics as we do
-  not need them and this avoids any issues with storing PII.
+- Add support for overriding server args through Helm values.
 
 ## [0.1.1] - 2021-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Ingress auth using Grafana authentication.
 
+### Changed
+
+- Avoids storing user labels (`user_name`, `user_email`) in metrics as we do
+  not need them and this avoids any issues with storing PII.
+
 ## [0.1.1] - 2021-07-29
 
 ### Changed

--- a/helm/macropower-analytics-panel-server/Chart.yaml
+++ b/helm/macropower-analytics-panel-server/Chart.yaml
@@ -9,5 +9,5 @@ sources:
 - https://github.com/MacroPower/macropower-analytics-panel/tree/master/server
 version: [[ .Version ]]
 annotations:
-  config.giantswarm.io/version: 1.x.x
+  config.giantswarm.io/version: "analytics-server-disable-user-metrics"
   application.giantswarm.io/team: "atlas"

--- a/helm/macropower-analytics-panel-server/Chart.yaml
+++ b/helm/macropower-analytics-panel-server/Chart.yaml
@@ -9,5 +9,5 @@ sources:
 - https://github.com/MacroPower/macropower-analytics-panel/tree/master/server
 version: [[ .Version ]]
 annotations:
-  config.giantswarm.io/version: "analytics-server-disable-user-metrics"
+  config.giantswarm.io/version: 1.x.x
   application.giantswarm.io/team: "atlas"

--- a/helm/macropower-analytics-panel-server/templates/deployment.yaml
+++ b/helm/macropower-analytics-panel-server/templates/deployment.yaml
@@ -33,7 +33,12 @@ spec:
       - name: {{ include "name" . }}
         image: "{{ .Values.registry.domain }}/{{ .Values.server.image.name }}:{{ .Values.server.image.tag }}"
         imagePullPolicy: {{ .Values.server.image.pullPolicy }}
-        args: {{ .Values.server.args }}
+        {{- if .Values.server.args }}
+        args:
+        {{- range $key, $value := .Values.server.args }}
+          - --{{ $key }}={{ $value }}
+        {{- end }}
+        {{- end }}
         ports:
         - containerPort: {{ .Values.server.port }}
           name: web

--- a/helm/macropower-analytics-panel-server/templates/deployment.yaml
+++ b/helm/macropower-analytics-panel-server/templates/deployment.yaml
@@ -33,8 +33,7 @@ spec:
       - name: {{ include "name" . }}
         image: "{{ .Values.registry.domain }}/{{ .Values.server.image.name }}:{{ .Values.server.image.tag }}"
         imagePullPolicy: {{ .Values.server.image.pullPolicy }}
-        args:
-        - --disable-user-metrics
+        args: {{ .Values.server.args }}
         ports:
         - containerPort: {{ .Values.server.port }}
           name: web

--- a/helm/macropower-analytics-panel-server/templates/deployment.yaml
+++ b/helm/macropower-analytics-panel-server/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- if .Values.server.args }}
         args:
         {{- range $key, $value := .Values.server.args }}
-          - --={{ $value }}
+          - {{ $value }}
         {{- end }}
         {{- end }}
         ports:

--- a/helm/macropower-analytics-panel-server/templates/deployment.yaml
+++ b/helm/macropower-analytics-panel-server/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
       - name: {{ include "name" . }}
         image: "{{ .Values.registry.domain }}/{{ .Values.server.image.name }}:{{ .Values.server.image.tag }}"
         imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+        args:
+        - --disable-user-metrics
         ports:
         - containerPort: {{ .Values.server.port }}
           name: web

--- a/helm/macropower-analytics-panel-server/templates/deployment.yaml
+++ b/helm/macropower-analytics-panel-server/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- if .Values.server.args }}
         args:
         {{- range $key, $value := .Values.server.args }}
-          - --{{ $key }}={{ $value }}
+          - --={{ $value }}
         {{- end }}
         {{- end }}
         ports:

--- a/helm/macropower-analytics-panel-server/values.yaml
+++ b/helm/macropower-analytics-panel-server/values.yaml
@@ -13,6 +13,8 @@ project:
   commit: "[[ .SHA ]]"
 
 server:
+  args: []
+
   image:
     name: giantswarm/macropower-analytics-panel-server
     tag: 0.0.1


### PR DESCRIPTION
Supersede: https://github.com/giantswarm/macropower-analytics-panel-server-app/pull/10

Closes giantswarm/giantswarm#18571

Add support for overriding server args through Helm values.