### PR TITLE
Preserve labels to expose some user data to analytics

### DIFF
--- a/helm/macropower-analytics-panel-server/templates/servicemonitor.yaml
+++ b/helm/macropower-analytics-panel-server/templates/servicemonitor.yaml
@@ -12,7 +12,7 @@ spec:
 {{ toYaml .Values.serviceMonitor.relabelings | indent 6 }}
     metricRelabelings:
     - action: "labeldrop"
-      regex: "(user.*)"
+      regex: "(user_(name|email))"
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}


### PR DESCRIPTION
Specifically, only drop personally identifiable information -
`user_name` and `user_email`. This leaves `user_role`, `user_locale`,
`user_theme` and `user_timezone` in.

Towards: https://github.com/giantswarm/roadmap/issues/448

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
