### PR TITLE
enable externaldns support on ingress objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add additional annotations on all `ingress` objects to support DNS record creation via `external-dns`
+
 ## [0.4.4] - 2023-01-10
 
 ### Changed

--- a/helm/macropower-analytics-panel-server/templates/ingress-auth.yaml
+++ b/helm/macropower-analytics-panel-server/templates/ingress-auth.yaml
@@ -9,6 +9,10 @@ metadata:
   namespace: {{ .Values.namespace }}
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
+    {{- if .Values.server.ingress.externalDNS }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.server.ingress.host }}
+    giantswarm.io/external-dns: managed
+    {{- end }}   
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/macropower-analytics-panel-server/templates/ingress.yaml
+++ b/helm/macropower-analytics-panel-server/templates/ingress.yaml
@@ -10,6 +10,10 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/auth-url: https://$host/grafana-auth
     nginx.ingress.kubernetes.io/rewrite-target: /write
+    {{- if .Values.server.ingress.externalDNS }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.server.ingress.host }}
+    giantswarm.io/external-dns: managed
+    {{- end }}   
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:

--- a/helm/macropower-analytics-panel-server/values.yaml
+++ b/helm/macropower-analytics-panel-server/values.yaml
@@ -25,6 +25,7 @@ server:
     port: 8080
 
   ingress:
+    externalDNS: false
     host: ""
     path: "/"
 
@@ -37,4 +38,4 @@ serviceMonitor:
   metricRelabelings: []
 
   relabelings:
-    - ''
+    - ""


### PR DESCRIPTION
to support dns-record creation via external-dns, two additional annotations are needed to make external-dns work on macropower-analytics-panel-server created ingress objects.

towards: https://github.com/giantswarm/roadmap/issues/1037
related config repo change: https://github.com/giantswarm/config/pull/1609

<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

This PR:

- adds/changes/removes etc

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
